### PR TITLE
Cache Tags

### DIFF
--- a/src/ApiEndpoints/ZoneApi.php
+++ b/src/ApiEndpoints/ZoneApi.php
@@ -119,4 +119,21 @@ class ZoneApi extends CloudFlareAPI {
     $this->makeRequest(self::REQUEST_TYPE_DELETE, $request_path, ['files' => $files]);
   }
 
+  /**
+   * Purges tags from CloudFlare.
+   *
+   * @param string $zone_id
+   *   The zoneId for the zone to access.
+   * @param array $tags
+   *   The list of tags to purge.
+   *
+   * @throws \CloudFlarePhpSdk\Exceptions\CloudFlareApiException
+   *   Throws an exception if there is an application level error returned from
+   *   the API.
+   */
+  public function purgeTags($zone_id, array $tags) {
+    $request_path = strtr('zones/:identifier/purge_cache', [':identifier' => $zone_id]);
+    $this->makeRequest(self::REQUEST_TYPE_DELETE, $request_path, ['tags' => $tags]);
+  }
+
 }

--- a/tests/ApiEndpoints/ZoneSettingsApiTest.php
+++ b/tests/ApiEndpoints/ZoneSettingsApiTest.php
@@ -93,6 +93,18 @@ class ZoneSettingsApiTest extends \PHPUnit_Framework_TestCase {
   /**
    * @dataProvider getPurgeIndividualFilesResponse
    */
+  function testPurgeCacheTags($response){
+    $mock = new MockHandler([
+      new Response(200, [], $response),
+    ]);
+
+    $api = new ZoneApi("api_key", "email", $mock);
+    $api->purgeTags("blah",['/alpha', 'beta']);
+  }
+
+  /**
+   * @dataProvider getPurgeIndividualFilesResponse
+   */
   function testPurgeFiles($response){
     $mock = new MockHandler([
       new Response(200, [], $response),


### PR DESCRIPTION
Added basic support for cache tags:
https://support.cloudflare.com/hc/en-us/articles/206596608-How-to-Purge-Cache-Using-Cache-Tags