### PR TITLE
Update purging limits

### DIFF
--- a/src/ApiEndpoints/CloudFlareAPI.php
+++ b/src/ApiEndpoints/CloudFlareAPI.php
@@ -56,8 +56,8 @@ abstract class CloudFlareAPI {
   // The CloudFlare API sets a maximum of 1,200 requests in a 5-minute period.
   const API_RATE_LIMIT = 1200;
 
-  // The CloudFlare API sets a maximum of 2000 requests in a 24-hour period.
-  const API_TAG_PURGE_DAILY_RATE_LIMIT = 2000;
+  // The CloudFlare API sets a maximum of 30000 requests in a 24-hour period.
+  const API_TAG_PURGE_DAILY_RATE_LIMIT = 30000;
 
   // Max Number of.
   const MAX_TAG_PURGES_PER_REQUEST = 30;


### PR DESCRIPTION
Cloudflare's API supports up to 30,000 cache tag purges in a day (I think).  

This is a bit unclear from Cloudflare's documentation, but they state that:
* Cache-Tag purging has a lower rate limit of up to 2,000 purge API calls in every 24 hour period. You may purge up to 30 tags in one API call. [source](https://api.cloudflare.com/#getting-started-requests)
* Cache-Tag and host purging each have a rate limit of 30,000 purge API calls in every 24 hour period. [source](https://api.cloudflare.com/#zone-purge-files-by-cache-tags-or-host)
* You may purge up to 30 tags in one API call, and make up to 30,000 purge API calls in every 24 hour period. [source](https://support.cloudflare.com/hc/en-us/articles/206596608-How-to-Purge-Cache-Using-Cache-Tags-Enterprise-only-)

I'm guessing that 30,000 is the new limit, and 2,000 was the limit they had in place while they were rolling this feature out, but it would be great to confirm that.