### PR TITLE
One more API Length PR

### DIFF
--- a/src/ApiEndpoints/CloudFlareAPI.php
+++ b/src/ApiEndpoints/CloudFlareAPI.php
@@ -47,11 +47,13 @@ abstract class CloudFlareAPI {
   const REQUEST_ALL_PAGES = -1;
   const API_ENDPOINT_BASE = 'https://api.cloudflare.com/client/v4/';
 
-  // The length of the Api key.
+  // The length of the Global Api key.
   // The Api will throw a non-descriptive http code: 400 exception if the key
   // length is greater than 37. If the key is invalid but the expected length
   // the Api will return a more informative http code of 403.
-  const API_KEY_LENGTH = 37;
+  const GLOBAL_API_KEY_LENGTH = 37;
+  // The length of the Api key.
+  const API_KEY_LENGTH = 40;
 
   // The CloudFlare API sets a maximum of 1,200 requests in a 5-minute period.
   const API_RATE_LIMIT = 1200;
@@ -63,10 +65,10 @@ abstract class CloudFlareAPI {
   const MAX_TAG_PURGES_PER_REQUEST = 30;
 
   // Time in seconds.
-  const HTTP_CONNECTION_TIMEOUT = 1.5;
+  const HTTP_CONNECTION_TIMEOUT = 15;
 
   // Time in seconds.
-  const HTTP_TIMEOUT = 3;
+  const HTTP_TIMEOUT = 30;
 
   // MAX Number of results returned by the API in one request.
   const MAX_ITEMS_PER_PAGE = 50;
@@ -93,10 +95,15 @@ abstract class CloudFlareAPI {
     $this->apikey = $apikey;
     $this->email = $email;
     $headers = [
-      'X-Auth-Key' => $apikey,
-      'X-Auth-Email' => $email,
       'Content-Type' => 'application/json',
     ];
+    if (strlen($apikey) === self::API_KEY_LENGTH) {
+      $headers['Authorization'] = 'Bearer ' . $apikey;
+    }
+    else {
+      $headers['X-Auth-Key'] = $apikey;
+      $headers['X-Auth-Email'] = $email;
+    }
 
     $client_params = [
       'base_uri' => self::API_ENDPOINT_BASE,
@@ -139,24 +146,7 @@ abstract class CloudFlareAPI {
     if (!isset($request_params['per_page'])) {
       $request_params['per_page'] = self::MAX_ITEMS_PER_PAGE;
     }
-    // This check seems superfluous.  However, the Api only returns a http 400
-    // code. This proactive check gives us more information.
-    $is_api_key_valid = strlen($this->apikey) == CloudFlareAPI::API_KEY_LENGTH;
-    $is_api_key_alpha_numeric = ctype_alnum($this->apikey);
-    $is_api_key_lower_case = !(preg_match('/[A-Z]/', $this->apikey));
-
-    if (!$is_api_key_valid) {
-      throw new CloudFlareInvalidCredentialException("Invalid Api Key: Key should be 37 chars long.", 403);
-    }
-
-    if (!$is_api_key_alpha_numeric) {
-      throw new CloudFlareInvalidCredentialException('Invalid Api Key: Key can only contain alphanumeric characters.', 403);
-    }
-
-    if (!$is_api_key_lower_case) {
-      throw new CloudFlareInvalidCredentialException('Invalid Api Key: Key can only contain lowercase or numerical characters.', 403);
-    }
-
+    
     try {
       switch ($request_type) {
         case self::REQUEST_TYPE_GET:


### PR DESCRIPTION
This builds on #33 and #34, but removes the self-identified "superfluous" checks. CloudFlare makes no official definition of what a token should be in [its documentation](https://api.cloudflare.com/#user-api-tokens-verify-token) and I think trying to chase that is now a fools errand. If the key is valid, it will turn successfully. If the key is invalid, it will fail. That's all we can plan for I think.