### PR TITLE
Allow Guzzle 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "guzzlehttp/guzzle": "~6.1"
+    "guzzlehttp/guzzle": "~6.1|^7.0"
   },
   "require-dev": {
     "drupal/coder": "8.2.*",


### PR DESCRIPTION
Drupal 10 requires Guzzle 7.

```
|--d8-contrib-modules/cloudflarephpsdk 1.0.0-alpha5 (requires guzzlehttp/guzzle ~6.1)
|  |--drupal/cloudflare 1.x-dev (requires d8-contrib-modules/cloudflarephpsdk ^1)
```

This SDK blocks the Cloudflare module from being compatible with Drupal 10.